### PR TITLE
fix: remove "name" and "about" key in frontmatter

### DIFF
--- a/.github/ISSUE_TEMPLATE/zz33-daily-todo.md
+++ b/.github/ISSUE_TEMPLATE/zz33-daily-todo.md
@@ -1,6 +1,4 @@
 ---
-name: My Daily Task List
-about: （このテンプレートは手動では使いません）
 title: "Daily: {{ date | date('add', 9, 'hours') | date('YYYY-MM-DD') }}"
 labels: ffxiv, daily, todo
 assignees: ndxbn


### PR DESCRIPTION
一旦、デイリーのテンプレートだけでやって、動作確認する