### PR TITLE
定期実行タスクで自分をアサインしなくした

### DIFF
--- a/.github/ISSUE_TEMPLATE/60-build-pc.md
+++ b/.github/ISSUE_TEMPLATE/60-build-pc.md
@@ -4,7 +4,7 @@ about: 新しく Windows Desktop PC を組み立てるときにやること
 title: New Desktop PC for XXXX
 labels: ["Type:Task"]
 projects: [ndxbn/7]
-assignees: ndxbn
+assignees: []
 ---
 
 See https://github.com/ndxbn/bootstrap-windows

--- a/.github/ISSUE_TEMPLATE/zz33-daily-todo.md
+++ b/.github/ISSUE_TEMPLATE/zz33-daily-todo.md
@@ -3,7 +3,7 @@ name: My Daily Task List
 about: （このテンプレートは手動では使いません）
 title: "Daily: {{ date | date('add', 9, 'hours') | date('YYYY-MM-DD') }}"
 labels: FF14, Occurring:Daily, Type:Task, bot
-assignees: ndxbn
+assignees: []
 ---
 [修正](https://github.com/ndxbn/ndxbn/edit/main/.github/ISSUE_TEMPLATE/zz33-daily-todo.md)
 

--- a/.github/ISSUE_TEMPLATE/zz34-weekly-todo.md
+++ b/.github/ISSUE_TEMPLATE/zz34-weekly-todo.md
@@ -3,7 +3,7 @@ name: My Weekly Task List
 about: （このテンプレートは手動では使いません）
 title: "Weekly: {{ date | date('add', 9, 'hours') | date('YYYY-MM-DD') }} ～ {{ date | date('add', 9, 'hours') | date('add', 6, 'days') | date('YYYY-MM-DD') }}"
 labels: FF14, Occurring:Weekly, Type:Task, bot
-assignees: ndxbn
+assignees: []
 ---
 [修正](https://github.com/ndxbn/ndxbn/edit/main/.github/ISSUE_TEMPLATE/zz34-weekly-todo.md)
 

--- a/.github/ISSUE_TEMPLATE/zz35-monthly-todo.md
+++ b/.github/ISSUE_TEMPLATE/zz35-monthly-todo.md
@@ -3,7 +3,7 @@ name: My Monthly Task List
 about: （このテンプレートは手動では使いません）
 title: "Monthly: {{ date | date('add', 9, 'hours') | date('YYYY-MM') }}"
 labels: FF14, Occurring:Monthly, Type:Task, bot
-assignees: ndxbn
+assignees: []
 ---
 [修正](https://github.com/ndxbn/ndxbn/edit/main/.github/ISSUE_TEMPLATE/zz35-monthly-todo.md)
 

--- a/.github/ISSUE_TEMPLATE/zz38-yearly-todo.md
+++ b/.github/ISSUE_TEMPLATE/zz38-yearly-todo.md
@@ -3,7 +3,7 @@ name: My Yearly Task List
 about: （このテンプレートは手動では使いません）
 title: "Yearly: {{ date | date('add', 1, 'year') | date('YYYY') }}"
 labels: FF14, Occurring:Yearly, Type:Task, bot
-assignees: ndxbn
+assignees: []
 ---
 [編集](https://github.com/ndxbn/ndxbn/edit/main/.github/ISSUE_TEMPLATE/zz38-yearly-todo.md)
 


### PR DESCRIPTION
いままでは、アサインされたときの通知を切っていたけれど、ON にしたほうが都合が良くなった。

しかし、その場合は定期タスクのアサイン通知は不要なので。