### PR TITLE
Disable profile badge workflow

### DIFF
--- a/.github/workflows/profile-badge.yml
+++ b/.github/workflows/profile-badge.yml
@@ -1,9 +1,9 @@
 name: Generate profile cards for README
 on:
-  schedule: [{cron: "0 */6 * * *"}]
   workflow_dispatch:
-  push: 
-    branches: [main]
+  # schedule: [{cron: "0 */6 * * *"}]
+  # push: 
+  #   branches: [main]
 jobs:
   github-metrics:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 <a href="https://redis.io" target="_blank"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/redis/redis-original-wordmark.svg" alt="Redis" width="50"/></a>
 <a href="https://www.rabbitmq.com/" target="_blank"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/rabbitmq/rabbitmq-original.svg" alt="Redis" width="50"/></a>
 
+<!--
 [![ndxbn's GitHub Stats](https://github-readme-stats-ten-blue-49.vercel.app/api?username=ndxbn&show_icons=true&count_private=true&theme=dark)](https://github.com/anuraghazra/github-readme-stats)
+-->
 
 <details><summary>More Stats</summary>
   


### PR DESCRIPTION
Action のバージョン追従がめんどくさいため。
Fork してきて自前で生成できるようにしたい。

<!--
"The CL author’s guide to getting through code review" https://google.github.io/eng-practices/review/developer
-->
